### PR TITLE
[Docker/s2i] Added start script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-contrib-uglify": "~0.5.0"
   },
   "scripts": {
-    "start": "node bot.js"
+    "start": "if [ $NO_LOADER = \"1\" ]; then node bot.js; else node index.js; fi"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-contrib-uglify": "~0.5.0"
   },
+  "scripts": {
+    "start": "node bot.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/YSITD/irc-reply-bot.git"


### PR DESCRIPTION
In order for s2i (source to image) build to work, a start script is required in order to allow the bot to start when the final Docker image runs. This commit adds the missing start script, allowing it to run correctly.